### PR TITLE
Update test_patterns

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,6 @@
 version = 1
 
-test_patterns = ["tests/"]
+test_patterns = ["tests/**"]
 
 exclude_patterns = [
     "dist/",


### PR DESCRIPTION
`test_pattern` field expects a list of glob patterns to discover the test files.
This change will fix the false-positive in `BAN-B101`